### PR TITLE
(for discussion) uWSGI + Plack support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-# Created by .ignore support plugin (hsz.mobi)
+/Makefile
+/MYMETA.*
+/META.*
+/blib/
+/pm_to_blib
+/Devel-Camelcadedb*

--- a/lib/Devel/Camelcadedb.pm
+++ b/lib/Devel/Camelcadedb.pm
@@ -992,7 +992,9 @@ sub _get_real_path_by_normalized_perl_file_id
     if (!exists $_perl_file_id_to_path_map{$perl_file_id})
     {
         no strict 'refs';
-        my $real_path = _calc_real_path( ${*{"::_<$perl_file_id"}}, $perl_file_id );
+        my $path = ${*{"::_<$perl_file_id"}};
+        return '' unless defined $path; # some subs created via XS
+        my $real_path = _calc_real_path( $path, $perl_file_id );
 
         $_perl_file_id_to_path_map{$perl_file_id} = $real_path;
         $_paths_to_perl_file_id_map{$real_path} = $perl_file_id;

--- a/lib/Devel/Camelcadedb.pm
+++ b/lib/Devel/Camelcadedb.pm
@@ -1767,7 +1767,7 @@ sub _connect
                 ReuseAddr => 1,
                 Proto     => 'tcp',
             );
-            last if $_debug_socket;
+            last if $_debug_socket || $attempt == $attempts;
             sleep( 1 ); # this is kinda hacky
         }
         die "Error connecting to $ENV{PERL5_DEBUG_HOST}:$ENV{PERL5_DEBUG_PORT}" if !$_debug_socket && !$allow_fail;

--- a/lib/Devel/Camelcadedb.pm
+++ b/lib/Devel/Camelcadedb.pm
@@ -1199,6 +1199,8 @@ sub _set_up_debugger
 
 sub _set_up_after_connect
 {
+    my ($allow_fail) = @_;
+
     $_debug_socket->autoflush( 1 );
     $_debug_socket_select = IO::Select->new();
     $_debug_socket_select->add( $_debug_socket );
@@ -1209,6 +1211,7 @@ sub _set_up_after_connect
     } );
     _report "Waiting for set up data..." if $_dev_mode;
     my $set_up_data = <$_debug_socket>;
+    return if !defined $set_up_data && $allow_fail;
     die "Connection closed" unless defined $set_up_data;
 
     $ready_to_go = 1;
@@ -1772,7 +1775,7 @@ sub _connect
         }
         die "Error connecting to $ENV{PERL5_DEBUG_HOST}:$ENV{PERL5_DEBUG_PORT}" if !$_debug_socket && !$allow_fail;
     }
-    _set_up_after_connect() if $_debug_socket;
+    _set_up_after_connect( $allow_fail ) if $_debug_socket;
 }
 
 sub connect

--- a/lib/Devel/Camelcadedb.pod
+++ b/lib/Devel/Camelcadedb.pod
@@ -25,6 +25,43 @@ providing template source file path and reference to the hash of lines map C<< t
         }
     }
 
+=head1 FUNCTIONS
+
+=head2 connect_or_reconnect
+
+    DB::connect_or_reconnect();
+
+Tries to connect to the IDE, use C<is_connected> to check whether the
+attempt was successful. Most useful when setting
+C<$ENV{PERL5_DEBUG_AUTOSTART}> to C<0> to avoid connecting at program
+startup.
+
+=head2 is_connected
+
+    $is_connected = DB::is_connected();
+
+Checks whether there is an active connection to the IDE.
+
+=head2 disconnect
+
+    DB::disconnect();
+
+Disconnects from the IDE.
+
+=head2 disable
+
+    DB::disable();
+
+Disables the most expensive debugger hooks, so execution speed is not
+affacted; the debugger is not functional while disabled, but it can be
+re-enabled at any time.
+
+=head2 enable
+
+    DB::enable();
+
+Re-enables debugging after a C<diable> call.
+
 =head1 AUTHORS
 
 2016 Alexandr Evstigneev  L<hurricup@gmail.com|mailto:hurricup@gmail.com>


### PR DESCRIPTION
Hi,
first of all, I'm very excited about remote debugging support in the Perl/IDEA plugin, thanks for working on it!

The specific use case I have at work is debugging various large Plack applications running under uWSGI (with pre-forking). What I have for other editors/IDEs (using https://github.com/mbarbon/perl-remote-debugging-client and https://github.com/mbarbon/plack-middleware-dbgp) is:
- during application startup debugging is disabled by default; $^P is setup in a way so that the code is prepared for debugging but DB::DB and  DB::sub are not called (so the overhead is close to 0)
- at request start the uWSGI child process serving the request tries to connect to the IDE; if it fails, debugging is kept disabled (again, with close to 0 overhead)
- if the connection is successful, debugging is enabled
- at request end, the uWSGI child disconnects from the IDE and disables debugging

I'd like to replicate the same setup with IDEA, and I have a tentative set of changes in this pull request (I only tested this on a trivial test application, so I might need some tweaks once I test it at work). Example usage is at https://github.com/mbarbon/plack-middleware-camelcadedb/blob/master/lib/Plack/Middleware/Camelcadedb.pm#L116
- if $ENV{PERL5_DEBUG_AUTOSTART} is explicitly set to 0, no connection attempt is performed during application startup
- adds connect(), disconnect(), is_connected(), connect_or_reconnect() for explicit connection management
- adds disable() to disable calls to DB::DB and DB::sub, and a matching enable()

Not in this PR, and wishlist, I'd like to add an option to connect over an Unix domain socket (I will need to use connection forwarding anyway, and using an Unix domain avoids the need for an open port on the application host which communicates directly with the IDE). I'd like to have this because the development environment is semi-shared, but it's not critical.

Let me know if this set of changes is something you're interested in incorporating, and if there is anything you would prefer to be done a different way (I will document the changes in the final PR).

Thanks!
Mattia
